### PR TITLE
Fix pathsep fastglob

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,8 +37,6 @@ function getFiles(glob){
 	const fold = fg.sync(glob);
 	let files = {};
 	
-	
-
 	for (let f in fold){
 		let relative_path = fold[f];
 		let separator = (relative_path.includes("/")) ? '/' : '\\';

--- a/index.js
+++ b/index.js
@@ -32,14 +32,18 @@ fs.writeJSONSync('src/data/tutorials.json', tuts, {spaces : 2});
 
 // return a list of files in json format 
 // with key: filename value: path
+// Using FastGlob, that does not give windows path separators on windows.
 function getFiles(glob){
 	const fold = fg.sync(glob);
 	let files = {};
+	
+	
 
 	for (let f in fold){
-		let file = path.parse(fold[f]);
-		let rel = fold[f].split(path.sep).slice(1).join('/');
-		files[file.name] = rel;
+		let relative_path = fold[f];
+		let separator = (relative_path.includes("/")) ? '/' : '\\';
+		let file = path.parse(relative_path);
+		files[file.name] = fold[f].split(separator).slice(1).join(separator);
 	}
 	return files;
 }

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ fs.writeJSONSync('src/data/tutorials.json', tuts, {spaces : 2});
 function getFiles(glob){
 	const fold = fg.sync(glob);
 	let files = {};
-	
+
 	for (let f in fold){
 		let relative_path = fold[f];
 		let separator = (relative_path.includes("/")) ? '/' : '\\';


### PR DESCRIPTION
FastGlobs path separator on windows is not the windows path separator (https://github.com/mrmlnc/fast-glob/releases/tag/3.0.0).. appearantly on purpose.... nice...

this fixes it and supports a version that does use the backslash path separator