### PR TITLE
New scopes for Editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "fs-extra": "^9.1.0",
         "hydra-synth": "1.3.17",
         "mercury-examples": "^1.0.8",
-        "mercury-lang": "^1.10.0",
+        "mercury-lang": "^1.11.0",
         "node-osc": "^8.0.6",
         "p5": "^1.4.2",
         "raf-loop": "^1.1.3",
@@ -2217,14 +2217,14 @@
       "license": "ISC"
     },
     "node_modules/mercury-lang": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/mercury-lang/-/mercury-lang-1.10.0.tgz",
-      "integrity": "sha512-ReYJBmnEA3TTNeCHCaVxUHXJXKKLuE2oR0XdoqTbqqVxPqunVzU27NcGWlZsR0jqrH7sftJJC8uhejfBJoOmyw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/mercury-lang/-/mercury-lang-1.11.0.tgz",
+      "integrity": "sha512-Xl+qpWHsfVkGI82mk1GZzgcoJjs8oXLyr1c/XAdi56spV4ufLGX3vNA8Wpq/39JLwp1c6p6MLDUtWIsHMgpIWg==",
       "license": "ISC",
       "dependencies": {
         "moo": "^0.5.1",
         "nearley": "^2.20.1",
-        "total-serialism": "^2.8.0"
+        "total-serialism": "^2.10.0"
       }
     },
     "node_modules/merge-descriptors": {
@@ -3602,9 +3602,9 @@
       }
     },
     "node_modules/total-serialism": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/total-serialism/-/total-serialism-2.8.0.tgz",
-      "integrity": "sha512-9fCIR3O4Z1WZOmzyOPMyT0d8sR+MP0vL6FhJBG6x+tgIe0Nl4qb5DKDi4P0RLf3W4xCTXoWKcQiqvQabQM6W6A==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/total-serialism/-/total-serialism-2.10.2.tgz",
+      "integrity": "sha512-oj32swligYzGRY48CwekgCiIWzVbHwNXxTDkWMpmlGIJZb4mhC1uUEgNVixygzZNApa+MsP8T+CUYTtB++4CaA==",
       "license": "MIT",
       "dependencies": {
         "@tonaljs/tonal": "^3.7.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "fs-extra": "^9.1.0",
     "hydra-synth": "1.3.17",
     "mercury-examples": "^1.0.8",
-    "mercury-lang": "^1.10.0",
+    "mercury-lang": "^1.11.0",
     "node-osc": "^8.0.6",
     "p5": "^1.4.2",
     "raf-loop": "^1.1.3",

--- a/src/core/Instrument.js
+++ b/src/core/Instrument.js
@@ -6,9 +6,9 @@ const Sequencer = require('./Sequencer.js');
 
 // Basic class for all instruments
 class Instrument extends Sequencer {
-	constructor(engine, canvas){
+	constructor(engine, canvas, line){
 		// Inherit from Sequencer
-		super(engine, canvas);
+		super(engine, canvas, line);
 
 		// Instrument specific parameters
 		this._gain = [-6, 0];		
@@ -226,22 +226,22 @@ class Instrument extends Sequencer {
 		}
 	}
 
-	classScope(){
-		let w = new Widget.Scope();
+	scope(){
+		let w = new Widget.Scope(this._line);
 		this._widgets.push(w);
 		this.gain.connect(w.input());
 	}
 
-	classWaveform(){
-		let w = new Widget.WaveForm();
+	waveform(){
+		let w = new Widget.WaveForm(this._line);
 		this._widgets.push(w);
 		this.gain.connect(w.input());
 	}
 
-	spectrum(){
-		let w = new Widget.Spectrum();
-		this._widgets.push(w);
-		this.gain.connect(w.input());
-	}
+	// spectrum(){
+	// 	let w = new Widget.Spectrum(this._line);
+	// 	this._widgets.push(w);
+	// 	this.gain.connect(w.input());
+	// }
 }
 module.exports = Instrument;

--- a/src/core/Instrument.js
+++ b/src/core/Instrument.js
@@ -26,6 +26,9 @@ class Instrument extends Sequencer {
 		// The source to be defined by inheriting class
 		this.source;
 
+		// A place to add widgets to
+		this._widgets = [];
+
 		console.log('=> class Instrument()');
 	}
 
@@ -141,11 +144,11 @@ class Instrument extends Sequencer {
 		// this.adsr.dispose();
 		// remove all fx
 		this._fx.map((f) => f.delete());
-		console.log('=> disposed Instrument() with FX:', this._fx);
+		this._widgets.map(w => w?.delete());
+
+		console.log('=> disposed Instrument() with FX:', this._fx, 'and widgets:', this._widgets);
 
 		this.deleteScope();
-
-		this._scope?.delete();
 	}
 
 	amp(g, r){
@@ -226,9 +229,10 @@ class Instrument extends Sequencer {
 	}
 
 	classScope(){
-		this._scope = new Widget.Scope();
-		this.gain.connect(this._scope.input());
-		// this._scope.draw();
+		// this._scope = new Widget.Scope();
+		let w = new Widget.Scope();
+		this._widgets.push(w);
+		this.gain.connect(w.input());
 	}
 
 	scope(){

--- a/src/core/Instrument.js
+++ b/src/core/Instrument.js
@@ -226,22 +226,22 @@ class Instrument extends Sequencer {
 		}
 	}
 
-	scope(){
-		let w = new Widget.Scope(this._line);
+	scope(h=30){
+		let w = new Widget.Scope(this._line, h);
 		this._widgets.push(w);
 		this.gain.connect(w.input());
 	}
 
-	waveform(){
-		let w = new Widget.WaveForm(this._line);
+	waveform(h=30){
+		let w = new Widget.WaveForm(this._line, h);
 		this._widgets.push(w);
 		this.gain.connect(w.input());
 	}
 
-	// spectrum(){
-	// 	let w = new Widget.Spectrum(this._line);
-	// 	this._widgets.push(w);
-	// 	this.gain.connect(w.input());
-	// }
+	spectrum(h=30){
+		let w = new Widget.Spectrum(this._line, h);
+		this._widgets.push(w);
+		this.gain.connect(w.input());
+	}
 }
 module.exports = Instrument;

--- a/src/core/Instrument.js
+++ b/src/core/Instrument.js
@@ -237,5 +237,11 @@ class Instrument extends Sequencer {
 		this._widgets.push(w);
 		this.gain.connect(w.input());
 	}
+
+	spectrum(){
+		let w = new Widget.Spectrum();
+		this._widgets.push(w);
+		this.gain.connect(w.input());
+	}
 }
 module.exports = Instrument;

--- a/src/core/Instrument.js
+++ b/src/core/Instrument.js
@@ -147,8 +147,6 @@ class Instrument extends Sequencer {
 		this._widgets.map(w => w?.delete());
 
 		console.log('=> disposed Instrument() with FX:', this._fx, 'and widgets:', this._widgets);
-
-		this.deleteScope();
 	}
 
 	amp(g, r){
@@ -229,110 +227,15 @@ class Instrument extends Sequencer {
 	}
 
 	classScope(){
-		// this._scope = new Widget.Scope();
 		let w = new Widget.Scope();
 		this._widgets.push(w);
 		this.gain.connect(w.input());
 	}
 
-	scope(){
-		// this._waveform = new Tone.Waveform(4096);
-		this._meter = new Tone.Meter();
-		this._meter.normalRange = true;
-		this._meter.smoothing = 0;
-
-		// this._mono = new Tone.Mono().connect(this._waveform);
-		this._mono = new Tone.Mono().connect(this._meter);
-		this.gain.connect(this._mono);
-
-		this._waveCnv = document.createElement('canvas');
-		let ui = document.getElementById('ui');
-		ui.appendChild(this._waveCnv);
-
-		this._waveCnv.width = window.innerWidth * 0.9;
-		this._waveCnv.height = 30;
-
-		this._waveWidget = window.cm.cm.addLineWidget(window.cm.cm.lineCount()-1, this._waveCnv);
-
-		this._scopeMax = 0.00001;
-
-		this._historySize = 128;
-		this._history = new Array(this._historySize).fill(0);
-
-		let drawWaveform = () => {
-			// console.log(this._meter.getValue());
-			// let wave = this._waveform.getValue();
-	
-			// let downsample = 1, sum = 0, downArr = [];
-			// for (let i = 0; i < wave.length; i++){
-			// 	// min = Math.min(min, wave[i]);
-			// 	this._scopeMax = Math.max(this._scopeMax, Math.abs(wave[i]));
-			// 	sum += wave[i];
-			// 	if (i % downsample === downsample - 1){
-			// 		downArr.push(sum / downsample); 
-			// 		sum = 0;
-			// 	}
-			// }
-
-			let mtr = this._meter.getValue();
-			this._history.push(mtr);
-			this._scopeMax = Math.max(mtr, this._scopeMax);
-			this._history = this._history.slice(this._history.length - this._historySize, this._history.length);
-
-			let ctx = this._waveCnv.getContext('2d');
-			let halfHeight = this._waveCnv.height / 2;
-			let width = this._waveCnv.width;
-
-			ctx.clearRect(0, 0, this._waveCnv.width, this._waveCnv.height);
-			ctx.lineWidth = 2;
-			ctx.strokeStyle = window.getComputedStyle(document.documentElement).getPropertyValue('--accent');
-			ctx.beginPath();
-			// for (let i = 0; i < downArr.length; i++){
-			// 	let a = downArr[i] * (1 / this._scopeMax) * halfHeight + halfHeight;
-			// 	if (i === 0) {
-			// 		ctx.moveTo(0, a);
-			// 	} else {
-			// 		ctx.lineTo(i * (width / downArr.length), a);
-			// 	}
-			// }	
-			for (let i = 0; i < this._history.length; i++){
-				// let inv = (i % 2) ? -1 : 1;
-				let a = this._history[i] * (1 / this._scopeMax) * halfHeight + halfHeight;
-				if (i === 0){
-					ctx.moveTo(0, a);
-				} else {
-					ctx.lineTo(i * (width / this._history.length), a);
-				}
-			}
-			ctx.stroke();
-
-			ctx.beginPath();
-			for (let i = 0; i < this._history.length; i++){
-				// let inv = (i % 2) ? -1 : 1;
-				let a = -this._history[i] * (1 / this._scopeMax) * halfHeight + halfHeight;
-				if (i === 0){
-					ctx.moveTo(0, a);
-				} else {
-					ctx.lineTo(i * (width / this._history.length), a);
-				}
-			}
-			ctx.stroke();
-
-			requestAnimationFrame(drawWaveform);
-		}
-		this._wvfrm = requestAnimationFrame(drawWaveform);
-	}
-
-	deleteScope(){
-		this._waveCnv?.remove();
-		this._mono?.disconnect();
-		this._mono?.dispose();
-		this._waveform?.disconnect();
-		this._waveform?.dispose();
-		this._meter?.disconnect();
-		this._meter?.dispose();
-		this._waveWidget?.clear();
-		cancelAnimationFrame(this._wvfrm);
+	classWaveform(){
+		let w = new Widget.WaveForm();
+		this._widgets.push(w);
+		this.gain.connect(w.input());
 	}
 }
 module.exports = Instrument;

--- a/src/core/MonoSample.js
+++ b/src/core/MonoSample.js
@@ -3,9 +3,9 @@ const Util = require('./Util.js');
 const Instrument = require('./Instrument.js');
 
 class MonoSample extends Instrument {
-	constructor(engine, s, canvas){
-		super(engine, canvas);
-
+	constructor(engine, s, canvas, line){
+		super(engine, canvas, line);
+		
 		this._bufs = this._engine.getBuffers();
 		this._sound;
 		this.sound(s);

--- a/src/core/MonoSynth.js
+++ b/src/core/MonoSynth.js
@@ -5,9 +5,9 @@ const TL = require('total-serialism').Translate;
 const Instrument = require('./Instrument');
 
 class MonoSynth extends Instrument {
-	constructor(engine, t='saw', canvas){
+	constructor(engine, t='saw', canvas, line){
 		// Inherit from Instrument
-		super(engine, canvas);
+		super(engine, canvas, line);
 
 		this._wave = Util.toArray(t);
 		this._waveMap = {

--- a/src/core/PolyInstrument.js
+++ b/src/core/PolyInstrument.js
@@ -7,9 +7,9 @@ const Instrument = require('./Instrument.js');
 
 // Basic class for a poly-instrument
 class PolyInstrument extends Instrument {
-	constructor(engine, canvas){
+	constructor(engine, canvas, line){
 		// Inherit from Instrument
-		super(engine, canvas);
+		super(engine, canvas, line);
 
 		// The source to be defined by inheriting class
 		this.sources = [];

--- a/src/core/PolySample.js
+++ b/src/core/PolySample.js
@@ -3,9 +3,9 @@ const Util = require('./Util.js');
 const PolyInstrument = require('./PolyInstrument.js');
 
 class PolySample extends PolyInstrument {
-	constructor(engine, s, canvas){
+	constructor(engine, s, canvas, line){
 		// Inherit from PolyInstrument
-		super(engine, canvas);
+		super(engine, canvas, line);
 
 		this._bufs = this._engine.getBuffers();
 		this._sound;

--- a/src/core/PolySynth.js
+++ b/src/core/PolySynth.js
@@ -3,9 +3,9 @@ const Util = require('./Util.js');
 const PolyInstrument = require('./PolyInstrument');
 
 class PolySynth extends PolyInstrument {
-	constructor(engine, t='saw', canvas){
+	constructor(engine, t='saw', canvas, line){
 		// Inherit from PolyInstrument
-		super(engine, canvas);
+		super(engine, canvas, line);
 
 		// synth specific variables;
 		this._wave = Util.toArray(t);

--- a/src/core/Sequencer.js
+++ b/src/core/Sequencer.js
@@ -6,7 +6,9 @@ class Sequencer {
 	constructor(engine, canvas, line){
 		// The Tone engine
 		this._engine = engine;
+		// The Hydra canvas
 		this._canvas = canvas;
+		// The line position in the editor of the instrument
 		this._line = line;
 		
 		// Sequencer specific parameters
@@ -29,7 +31,7 @@ class Sequencer {
 		this._once = false;
 		// this.makeLoop();
 
-		console.log('=> class Sequencer()', this._line);
+		console.log('=> class Sequencer()');
 	}
 
 	bpm(){

--- a/src/core/Sequencer.js
+++ b/src/core/Sequencer.js
@@ -3,10 +3,11 @@ const Util = require('./Util.js');
 
 // Basic Sequencer class for triggering events
 class Sequencer {
-	constructor(engine, canvas){
+	constructor(engine, canvas, line){
 		// The Tone engine
 		this._engine = engine;
 		this._canvas = canvas;
+		this._line = line;
 		
 		// Sequencer specific parameters
 		this._count = 0;
@@ -28,7 +29,7 @@ class Sequencer {
 		this._once = false;
 		// this.makeLoop();
 
-		console.log('=> class Sequencer()');
+		console.log('=> class Sequencer()', this._line);
 	}
 
 	bpm(){

--- a/src/core/Widgets.js
+++ b/src/core/Widgets.js
@@ -5,8 +5,8 @@ const Tone = require('tone');
 // a canvas that will be added as a line widget
 // a drawing loop, and some drawing functions like line
 class Widget {
-	constructor(){
-		// console.log('=> class Widget()');
+	constructor(line){
+		// console.log('=> class Widget()', line);
 		// to connect the source to and make it to mono for analysis
 		this.mono = new Tone.Mono();
 		// the canvas to display the visual in, adjust width and height
@@ -17,7 +17,8 @@ class Widget {
 		// get the 2d context from canvas
 		this.ctx = this.cnv.getContext('2d');
 		// create a new widget between the editor lines
-		this.widget = window.cm.cm.addLineWidget(window.cm.cm.lineCount() - 1, this.cnv);
+		this.widget = window.cm.cm.addLineWidget(line-1, this.cnv);
+		// this.widget = window.cm.cm.addLineWidget(line, this.cnv);		
 		// the auto scaling for the scope
 		this.scopeScale = -Infinity;
 	}
@@ -76,9 +77,9 @@ class Widget {
 // A scope widget, displays the audio signal with a fast
 // zoomed in scope. Has more erratic behaviour than waveform
 class Scope extends Widget {
-	constructor(){
-		console.log('=> class Scope()');
-		super();
+	constructor(...args){
+		// console.log('=> class Scope()');
+		super(...args);
 
 		// create the waveform analysis from Tone
 		this.waveform = new Tone.Waveform(4096);
@@ -125,9 +126,9 @@ class Scope extends Widget {
 // of the signal measured of a short period of time
 // This visualisation looks more like a waveform display in a DAW
 class WaveForm extends Widget {
-	constructor(){
-		console.log('=> class WaveForm()');
-		super();
+	constructor(...args){
+		// console.log('=> class WaveForm()');
+		super(...args);
 		
 		// create the meter and use 0-1 range for values instead of dB
 		this.meter = new Tone.Meter();

--- a/src/core/Widgets.js
+++ b/src/core/Widgets.js
@@ -2,6 +2,7 @@ const Tone = require('tone');
 
 class Scope {
 	constructor(){
+		console.log('=> class Scope()');
 		this.waveform = new Tone.Waveform(4096);
 		this.mono = new Tone.Mono().connect(this.waveform);
 
@@ -19,10 +20,9 @@ class Scope {
 		
 		this.scopeScale = -Infinity;
 
-		// this.anim = requestAnimationFrame(this.draw);
 		let framedraw = () => {
 			this.draw();
-			requestAnimationFrame(framedraw);
+			this.anim = requestAnimationFrame(framedraw);
 		}
 		this.anim = requestAnimationFrame(framedraw);
 	}
@@ -75,6 +75,7 @@ class Scope {
 	}
 
 	delete(){
+		// console.log('Scope deleted');
 		cancelAnimationFrame(this.anim);
 		this.widget?.clear();
 		this.cnv?.remove();

--- a/src/core/Widgets.js
+++ b/src/core/Widgets.js
@@ -1,0 +1,87 @@
+const Tone = require('tone');
+
+class Scope {
+	constructor(){
+		this.waveform = new Tone.Waveform(4096);
+		this.mono = new Tone.Mono().connect(this.waveform);
+
+		this.cnv = document.createElement('canvas');
+		let ui = document.getElementById('ui');
+		ui.appendChild(this.cnv);
+
+		this.cnv.width = window.innerWidth * 0.9;
+		this.cnv.height = 25;
+
+		// get the 2d context from canvas
+		this.ctx = this.cnv.getContext('2d');
+
+		this.widget = window.cm.cm.addLineWidget(window.cm.cm.lineCount() - 1, this.cnv);
+		
+		this.scopeScale = -Infinity;
+
+		// this.anim = requestAnimationFrame(this.draw);
+		let framedraw = () => {
+			this.draw();
+			requestAnimationFrame(framedraw);
+		}
+		this.anim = requestAnimationFrame(framedraw);
+	}
+
+	// connect the scope to a Tone Audio Node with node.connect(scope.input())
+	input(){
+		return this.mono;
+	}
+
+	draw(){
+		// get the waveform array and downsample
+		let wave = this.waveform.getValue();
+		let downArr = this.downsample(wave, 1);
+		// erase the previous drawn line
+		this.ctx.clearRect(0, 0, this.cnv.width, this.cnv.height);
+		// draw the line from downsamples values
+		this.line(downArr);
+	}
+
+	downsample(arr, down=1){
+		let sum = 0, out = [];
+		for (let i = 0; i < arr.length; i++){
+			this.scopeScale = Math.max(this.scopeScale, Math.abs(arr[i]));
+			sum += arr[i];
+
+			if (i % down === down - 1){
+				out.push(sum / down);
+				sum = 0;
+			}
+		}
+		return out;
+	}
+
+	line(arr){
+		this.ctx.lineWidth = 2;
+		this.ctx.strokeStyle = window.getComputedStyle(document.documentElement).getPropertyValue('--accent');
+
+		let halfHeight = this.cnv.height / 2;
+		// begin the stroke, for every point draw a line, then end the stroke
+		this.ctx.beginPath();
+		for (let i = 0; i < arr.length; i++){
+			let a = arr[i] * (1 / this.scopeScale) * halfHeight + halfHeight;
+			if (i === 0) {
+				this.ctx.moveTo(0, a);
+			} else {
+				this.ctx.lineTo(i * (this.cnv.width / arr.length), a);
+			}
+		}
+		this.ctx.stroke();
+	}
+
+	delete(){
+		cancelAnimationFrame(this.anim);
+		this.widget?.clear();
+		this.cnv?.remove();
+		this.waveform?.disconnect();
+		this.waveform?.dispose();
+		this.mono?.disconnect();
+		this.mono?.dispose();
+	}
+}
+module.exports = { Scope };

--- a/src/main.js
+++ b/src/main.js
@@ -182,7 +182,7 @@ window.onload = () => {
 	// the code Editor
 	// also loads the parser and the worker
 	// gets passed the Tone context and Engine
-	let cm = new Editor({ context: Tone, engine: Engine, canvas: Hydra, p5canvas: sketchP5 });
+	window.cm = new Editor({ context: Tone, engine: Engine, canvas: Hydra, p5canvas: sketchP5 });
 
 	// Load all the buttons/menus
 	cm.controls();

--- a/src/worker.js
+++ b/src/worker.js
@@ -176,7 +176,7 @@ function code({ file, engine, canvas, p5canvas }){
 			// console.log('make sample', obj);
 			let type = obj.type;
 			let args = obj.functions;			
-			let inst = new MonoSample(engine, type, canvas);
+			let inst = new MonoSample(engine, type, canvas, obj.line);
 
 			objectMap.applyFunctions(args, inst, type);
 			return inst;
@@ -185,7 +185,7 @@ function code({ file, engine, canvas, p5canvas }){
 			// console.log('make sample', obj);
 			let type = obj.type;
 			let args = obj.functions;			
-			let inst = new MonoSample(engine, type, canvas);
+			let inst = new MonoSample(engine, type, canvas, obj.line);
 
 			objectMap.applyFunctions(args, inst, type);
 			return inst;
@@ -194,7 +194,7 @@ function code({ file, engine, canvas, p5canvas }){
 			// console.log('make synth', obj);
 			let type = obj.type;
 			let args = obj.functions;			
-			let inst = new MonoSynth(engine, type, canvas);
+			let inst = new MonoSynth(engine, type, canvas, obj.line);
 
 			objectMap.applyFunctions(args, inst, type);
 			return inst;
@@ -202,7 +202,7 @@ function code({ file, engine, canvas, p5canvas }){
 		'polySynth' : (obj) => {
 			let type = obj.type;
 			let args = obj.functions;
-			let inst = new PolySynth(engine, type, canvas);
+			let inst = new PolySynth(engine, type, canvas, obj.line);
 			// let inst = new PolySample(engine, type, canvas);
 
 			objectMap.applyFunctions(args, inst, type);
@@ -211,7 +211,7 @@ function code({ file, engine, canvas, p5canvas }){
 		'polySample' : (obj) => {
 			let type = obj.type;
 			let args = obj.functions;
-			let inst = new PolySample(engine, type, canvas);
+			let inst = new PolySample(engine, type, canvas, obj.line);
 			
 			objectMap.applyFunctions(args, inst, type);
 			return inst;
@@ -220,7 +220,7 @@ function code({ file, engine, canvas, p5canvas }){
 			// console.log('make midi', obj);
 			let device = obj.type;
 			let args = obj.functions;
-			let inst = new MonoMidi(engine, device, canvas);
+			let inst = new MonoMidi(engine, device, canvas, obj.line);
 
 			objectMap.applyFunctions(args, inst, device);
 			return inst;


### PR DESCRIPTION
Some new scopes to display in the editor between the instrument lines.

- `scope()` - display a fast moving amplitude scope
- `waveform()` - display an average rms measure, moving slowly (like a recording waveform)
- `spectrum()` - display the spectrum (FFT) of the sound