### PR TITLE
Lazy sample loading

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -76,14 +76,13 @@
 	<script type="text/javascript" src="./bundle.js"></script>
 	<!-- <script type="text/javascript" src="./bundle.min.js"></script> -->
 
-	<div id='load' class='loadscreen'>
-		<!-- <div class='loader'></div> -->
+	<!-- <div id='load' class='loadscreen'>
 		<div class='loadText'>
 			<p id='log'> 
 				Waking up...<br><br>
 			</p>
 		</div>
-	</div>
+	</div> -->
 
 	<div id="p5-canvas" class="canvas"></div>
 	<canvas id="hydra-canvas" class="canvas"></canvas>

--- a/src/core/Instrument.js
+++ b/src/core/Instrument.js
@@ -10,6 +10,10 @@ class Instrument extends Sequencer {
 		// Inherit from Sequencer
 		super(engine, canvas, line);
 
+		// reference to all the default samples to be used
+		// by inheriting classes monosample, polysample
+		this._defaults = this._engine.getDefaultSamples();
+
 		// Instrument specific parameters
 		this._gain = [ 0.5, 0 ];		
 		this._pan = [ 0 ];

--- a/src/core/MonoSample.js
+++ b/src/core/MonoSample.js
@@ -2,12 +2,13 @@ const Tone = require('tone');
 const Util = require('./Util.js');
 const Instrument = require('./Instrument.js');
 
-const defaultSamples = require('./../data/samples.json');
+// const defaultSamples = require('./../data/samples.json');
 
 class MonoSample extends Instrument {
 	constructor(engine, s, canvas, line){
 		super(engine, canvas, line);
 		
+		this._defaults = this._engine.getDefaultSamples();
 		this._bufs = this._engine.getBuffers();
 		this._sound;
 		this.sound(s);
@@ -46,8 +47,8 @@ class MonoSample extends Instrument {
 		}
 
 		if (!this._bufs.has(f)){
-			if (defaultSamples[f]){
-				this._engine.addBufferFromURL(defaultSamples[f], f);
+			if (this._defaults[f]){
+				this._engine.addBufferFromURL(this._defaults[f], f);
 			} else {
 				// default sample if file does not exist
 				log(`${f} is not a loaded sample name and not part of default pack`);
@@ -62,9 +63,6 @@ class MonoSample extends Instrument {
 		} else {
 			// don't play if there is no valid buffer loaded
 			return;
-			// default sample if file does not exist
-			// this.sample.buffer = this._bufs.get('kick_min');
-			// this.sample.buffer = this._bufs.get('kick_min').slice(0);
 		}
 		
 		// get speed and if 2d array pick randomly
@@ -109,25 +107,8 @@ class MonoSample extends Instrument {
 
 	sound(s){
 		// load all soundfiles and return as array
-		// this._sound = this.checkBuffer(Util.toArray(s));
+		// check for correct filename when playing sound
 		this._sound = Util.toArray(s);
-	}
-
-	checkBuffer(a){
-		// check if file is part of the loaded samples
-		return a.map((s) => {
-			if (Array.isArray(s)) {
-				return this.checkBuffer(s);
-			}
-			// error if soundfile does not exist
-			else if (!defaultSamples[s] && !this._bufs.has(s)){
-			// else if (!this._bufs.has(s)){
-				// set default (or an ampty soundfile?)
-				log(`sample ${s} not found`);
-				return 'kick_909';
-			}
-			return s;
-		});
 	}
 
 	speed(s){

--- a/src/core/MonoSample.js
+++ b/src/core/MonoSample.js
@@ -2,6 +2,8 @@ const Tone = require('tone');
 const Util = require('./Util.js');
 const Instrument = require('./Instrument.js');
 
+const defaultSamples = require('./../data/samples.json');
+
 class MonoSample extends Instrument {
 	constructor(engine, s, canvas, line){
 		super(engine, canvas, line);
@@ -44,18 +46,24 @@ class MonoSample extends Instrument {
 		}
 
 		if (!this._bufs.has(f)){
-			// default sample if file does not exist
-			log(`${w} is not a valid sample name`);
-			// default sample is kick_909
-			f = 'kick_909';
+			if (defaultSamples[f]){
+				this._engine.addBufferFromURL(defaultSamples[f], f);
+			} else {
+				// default sample if file does not exist
+				log(`${f} is not a loaded sample name and not part of default pack`);
+				// default sample is kick_909
+				f = 'kick_909';
+			}
 		}
 
 		if (this._bufs.has(f)){	
 			this.sample.buffer = this._bufs.get(f);
 			// this.sample.buffer = this._bufs.get(f).slice(0);
 		} else {
+			// don't play if there is no valid buffer loaded
+			return;
 			// default sample if file does not exist
-			this.sample.buffer = this._bufs.get('kick_min');
+			// this.sample.buffer = this._bufs.get('kick_min');
 			// this.sample.buffer = this._bufs.get('kick_min').slice(0);
 		}
 		
@@ -101,7 +109,8 @@ class MonoSample extends Instrument {
 
 	sound(s){
 		// load all soundfiles and return as array
-		this._sound = this.checkBuffer(Util.toArray(s));
+		// this._sound = this.checkBuffer(Util.toArray(s));
+		this._sound = Util.toArray(s);
 	}
 
 	checkBuffer(a){
@@ -111,7 +120,8 @@ class MonoSample extends Instrument {
 				return this.checkBuffer(s);
 			}
 			// error if soundfile does not exist
-			else if (!this._bufs.has(s)){
+			else if (!defaultSamples[s] && !this._bufs.has(s)){
+			// else if (!this._bufs.has(s)){
 				// set default (or an ampty soundfile?)
 				log(`sample ${s} not found`);
 				return 'kick_909';

--- a/src/core/MonoSample.js
+++ b/src/core/MonoSample.js
@@ -8,7 +8,6 @@ class MonoSample extends Instrument {
 	constructor(engine, s, canvas, line){
 		super(engine, canvas, line);
 		
-		this._defaults = this._engine.getDefaultSamples();
 		this._bufs = this._engine.getBuffers();
 		this._sound;
 		this.sound(s);
@@ -52,17 +51,11 @@ class MonoSample extends Instrument {
 			} else {
 				// default sample if file does not exist
 				log(`${f} is not a loaded sample name and not part of default pack`);
-				// default sample is kick_909
-				f = 'kick_909';
 			}
-		}
-
-		if (this._bufs.has(f)){	
-			this.sample.buffer = this._bufs.get(f);
-			// this.sample.buffer = this._bufs.get(f).slice(0);
-		} else {
 			// don't play if there is no valid buffer loaded
 			return;
+		} else {
+			this.sample.buffer = this._bufs.get(f);
 		}
 		
 		// get speed and if 2d array pick randomly

--- a/src/core/PolySample.js
+++ b/src/core/PolySample.js
@@ -58,12 +58,27 @@ class PolySample extends PolyInstrument {
 			// clean-up previous buffer
 			this.sources[id].buffer.dispose();
 		}
-		if (this._bufs.has(b)){	
-			this.sources[id].buffer = this._bufs.get(b);
+
+		// if (this._bufs.has(b)){	
+		// 	this.sources[id].buffer = this._bufs.get(b);
+		// } else {
+		// 	// default sample if file does not exist
+		// 	this.sources[id].buffer = this._bufs.get('kick_min');
+		// }
+
+		if (!this._bufs.has(b)){
+			if (this._defaults[b]){
+				this._engine.addBufferFromURL(this._defaults[b], b);
+			} else {
+				// default sample if file does not exist
+				log(`${f} is not a loaded sample name and not part of default pack`);
+			}
+			// don't play if there is no valid buffer loaded
+			return;
 		} else {
-			// default sample if file does not exist
-			this.sources[id].buffer = this._bufs.get('kick_min');
+			this.sources[id].buffer = this._bufs.get(b);
 		}
+
 		// the duration of the buffer in seconds
 		let dur = this.sources[id].buffer.duration;
 
@@ -109,24 +124,25 @@ class PolySample extends PolyInstrument {
 
 	sound(s){
 		// load all soundfiles and return as array
-		this._sound = this.checkBuffer(Util.toArray(s));
+		// this._sound = this.checkBuffer(Util.toArray(s));
+		this._sound = Util.toArray(s);
 	}
 
-	checkBuffer(a){
-		// check if file is part of the loaded samples
-		return a.map((s) => {
-			if (Array.isArray(s)) {
-				return this.checkBuffer(s);
-			}
-			// error if soundfile does not exist
-			else if (!this._bufs.has(s)){
-				// set default (or an ampty soundfile?)
-				log(`sample ${s} not found`);
-				return 'kick_909';
-			}
-			return s;
-		});
-	}
+	// checkBuffer(a){
+	// 	// check if file is part of the loaded samples
+	// 	return a.map((s) => {
+	// 		if (Array.isArray(s)) {
+	// 			return this.checkBuffer(s);
+	// 		}
+	// 		// error if soundfile does not exist
+	// 		else if (!this._bufs.has(s)){
+	// 			// set default (or an ampty soundfile?)
+	// 			log(`sample ${s} not found`);
+	// 			return 'kick_909';
+	// 		}
+	// 		return s;
+	// 	});
+	// }
 
 	note(i=0, o=0){
 		// set the note as semitone interval and octave offset

--- a/src/editor.js
+++ b/src/editor.js
@@ -29,9 +29,6 @@ console.log('=> examples loaded', examples);
 const tutorials = require('mercury-examples').Tutorials;
 console.log('=> tutorials loaded', tutorials);
 
-// get the samplefile path data
-let samples = require('./data/samples.json');
-
 // the simple mode lexer for Mercury syntax-highlighting
 CodeMirror.defineSimpleMode("mercury", {
 	meta: {
@@ -579,15 +576,26 @@ const Editor = function({ context, engine, canvas, p5canvas }) {
 			document.getElementById('sounds').value = 'sounds';
 			this.insertSound(s);
 		}
-
-		let values = ['sounds'].concat(Object.keys(samples));
-		values.forEach((t) => {
-			let option = document.createElement('option');
-			option.value = option.innerHTML = t;
-			// also add the sample names to the hint autocomplete
-			mercuryHintList.push(t);
-			menu.appendChild(option);
-		});
+		menu.build = () => {
+			menu.innerHTML = '';
+			// get all the values from the default samples
+			let values = ['sounds'].concat(Object.keys(engine.getDefaultSamples()));
+			// get the keys from the loaded buffers and merge them
+			values = values.concat(Array.from(engine.getBuffers()._buffers.keys()));
+			// remove the duplicates
+			values = [...new Set(values) ];
+			values.forEach((t) => {
+				let option = document.createElement('option');
+				option.value = option.innerHTML = t;
+				// also add the sample names to the hint autocomplete
+				mercuryHintList.push(t);
+				menu.appendChild(option);
+			});
+		}
+		menu.build();
+		menu.onmouseenter = () => {
+			menu.build();
+		}
 	}
 
 	this.insertSound = function(s){
@@ -659,9 +667,14 @@ const Editor = function({ context, engine, canvas, p5canvas }) {
 	this.showListenMenu = function(show){
 		let m = document.getElementById('sounds-prelisten-box');
 		if (show){
+			// build the menu
+			this.soundsListenMenu();
 			m.style.display = "block";
 		} else {
 			m.style.display = 'none';
+			// delete the content
+			let l =  document.getElementsByClassName('sounds-prelisten')[0];
+			l.innerHTML = '';
 		}
 		this.listenMenuVisible = show;
 	}
@@ -681,7 +694,13 @@ const Editor = function({ context, engine, canvas, p5canvas }) {
 		`
 		
 		let p = document.getElementById('sound-prelisten-items');
-		let sounds = ['sounds'].concat(Object.keys(samples));
+		// get all the values from the default samples
+		let sounds = ['sounds'].concat(Object.keys(engine.getDefaultSamples()));
+		// TO-DO: Show sounds that are added later, besides default samples
+		// get the keys from the loaded buffers and merge them
+		// sounds = sounds.concat(Array.from(engine.getBuffers()._buffers.keys()));
+		// remove the duplicates
+		// sounds = [...new Set(sounds) ];
 		let last = '';
 		for (let i=0; i<sounds.length; i++){
 			// skip the keyword sounds that is used for the dropdown menu
@@ -689,9 +708,9 @@ const Editor = function({ context, engine, canvas, p5canvas }) {
 			// create an audio element
 			let aud = document.createElement('audio');
 			aud.volume = 0.5;
-			aud.src = samples[sounds[i]];
+			aud.src = engine.getDefaultSamples()[sounds[i]];
 			aud.name = sounds[i];
-			aud.preload = 'auto';
+			aud.preload = 'none';
 			// create a button element
 			let btn = document.createElement('button');
 			btn.innerHTML = sounds[i];

--- a/src/engine.js
+++ b/src/engine.js
@@ -9,12 +9,12 @@ Tone.getContext().addAudioWorkletModule(URL.createObjectURL(new Blob([ fxExtensi
 
 // latency reduces cpu load
 // Tone.context.latencyHint = 'playback';
-Tone.context.lookAhead = 0.1;
+// Tone.context.lookAhead = 0.1;
 // Tone.context.updateInterval = 0.5;
-Tone.context.samplerate = 44100;
+// Tone.context.samplerate = 44100;
 
 log('Engine settings:');
-log(`  - latency: ${Tone.getContext().lookAhead * 1000}ms`);
+log(`  - lookAhead: ${Tone.getContext().lookAhead * 1000}ms`);
 log(`  - updateInterval: ${Tone.getContext().updateInterval * 1000}ms`);
 log(`  - latencyHint: ${Tone.getContext().latencyHint}`);
 log(`  - samplerate: ${Tone.getContext().sampleRate}Hz`);
@@ -177,10 +177,6 @@ function addBufferFromURL(url, n){
 		log(`sound added: ${n}`);
 		URL.revokeObjectURL(url);
 		// also add soundfiles to menu for easy selection
-		let m = document.getElementById('sounds');
-		let o = document.createElement('option');
-		o.value = o.innerHTML = n;
-		m.appendChild(o);
 	}, (e) => {
 		log(`error adding sound from: ${n}`);
 	});

--- a/src/engine.js
+++ b/src/engine.js
@@ -110,6 +110,12 @@ function getBuffers(){
 	return buffers;
 }
 
+function addDefaultBuffers(){
+	Object.keys(samples).forEach((s) => {
+		addBufferFromURL(samples[s], s);
+	});
+}
+
 // add files to the buffer from a single File Link
 // an array or file paths, or a json of { name:file, ... }
 function addBuffers(uploads){
@@ -142,8 +148,6 @@ function addBuffers(uploads){
 // if name is undefined it will be constructed from the URL
 // 
 function addBufferFromURL(url, n){
-	log(`loading sample: ${n}`);
-
 	// get file name from url string
 	n = n.split('\\').pop().split('/').pop();
 	// remove extension 
@@ -152,6 +156,13 @@ function addBufferFromURL(url, n){
 	n = n.replace(/[\s]+/g, '_');
 	// remove leading/trailing whitespace
 	n = n.trim().replace(/[\s]+/g, '_');
+
+	// can't have 2 samples with the sample name loaded
+	if (buffers.has(n)){
+		log(`sound '${n}' was already added to the library`);
+		return;
+	}
+	log(`loading sample: ${n}`);
 
 	// load buffer and add to ToneAudioBuffers array
 	const buffer = new Tone.ToneAudioBuffer(url, () => {
@@ -279,4 +290,4 @@ async function record(on, f){
 	}
 }
 
-module.exports = { resume, silence, setBPM, getBPM, randomBPM, getBuffers, addBuffers, setLowPass, setHiPass, setVolume, record, isRecording, addBufferFromURL };
+module.exports = { resume, silence, setBPM, getBPM, randomBPM, getBuffers, addBuffers, setLowPass, setHiPass, setVolume, record, isRecording, addBufferFromURL, addDefaultBuffers };

--- a/src/engine.js
+++ b/src/engine.js
@@ -13,12 +13,12 @@ Tone.context.lookAhead = 0.1;
 // Tone.context.updateInterval = 0.5;
 Tone.context.samplerate = 44100;
 
-console.log('=> Engine settings:');
-console.log(`latency: ${Tone.getContext().lookAhead * 1000}ms`);
-console.log(`updateInterval: ${Tone.getContext().updateInterval * 1000}ms`);
-console.log(`latencyHint: ${Tone.getContext().latencyHint}`);
-console.log(`samplerate: ${Tone.getContext().sampleRate}Hz`);
-console.log(`PPQ: ${Tone.Transport.PPQ}`);
+log('Engine settings:');
+log(`  - latency: ${Tone.getContext().lookAhead * 1000}ms`);
+log(`  - updateInterval: ${Tone.getContext().updateInterval * 1000}ms`);
+log(`  - latencyHint: ${Tone.getContext().latencyHint}`);
+log(`  - samplerate: ${Tone.getContext().sampleRate}Hz`);
+log(`  - PPQ: ${Tone.Transport.PPQ}`);
 
 // get the sample file paths from json
 // let loadingID = setInterval(() => {

--- a/src/engine.js
+++ b/src/engine.js
@@ -21,26 +21,27 @@ console.log(`samplerate: ${Tone.getContext().sampleRate}Hz`);
 console.log(`PPQ: ${Tone.Transport.PPQ}`);
 
 // get the sample file paths from json
-let loadingID = setInterval(() => {
-	console.log('downloading sounds...');
-}, 2500);
+// let loadingID = setInterval(() => {
+// 	console.log('downloading sounds...');
+// }, 2500);
 
 let samples = require('./data/samples.json');
-let buffers = new Tone.ToneAudioBuffers({
-	urls: samples,
-	onload: function(){ 
-		clearInterval(loadingID);
-		console.log('=> sounds loaded', buffers);
-		// remove the logging function to the innerHTML from here on
-		console.log = console.olog;
-		// init();
-		// remove loading screen, because probably this
-		// is the last thing that is done
-		setTimeout(() => {
-			document.getElementById('load').className = 'hideLoad';
-		}, 1000);
-	}
-});
+let buffers = new Tone.ToneAudioBuffers();
+// let buffers = new Tone.ToneAudioBuffers({
+// 	urls: samples,
+// 	onload: function(){ 
+// 		clearInterval(loadingID);
+// 		console.log('=> sounds loaded', buffers);
+// 		// remove the logging function to the innerHTML from here on
+// 		console.log = console.olog;
+// 		// init();
+// 		// remove loading screen, because probably this
+// 		// is the last thing that is done
+// 		setTimeout(() => {
+// 			document.getElementById('load').className = 'hideLoad';
+// 		}, 1000);
+// 	}
+// });
 
 // resume webaudio and transport for livecoding
 function resume(){
@@ -141,6 +142,8 @@ function addBuffers(uploads){
 // if name is undefined it will be constructed from the URL
 // 
 function addBufferFromURL(url, n){
+	log(`loading sample: ${n}`);
+
 	// get file name from url string
 	n = n.split('\\').pop().split('/').pop();
 	// remove extension 
@@ -150,11 +153,12 @@ function addBufferFromURL(url, n){
 	// remove leading/trailing whitespace
 	n = n.trim().replace(/[\s]+/g, '_');
 
-	// add to ToneAudioBuffers
-	buffers.add(n, url, () => {
-		log(`sound added as: ${n}`);
-		URL.revokeObjectURL(url);
+	// load buffer and add to ToneAudioBuffers array
+	const buffer = new Tone.ToneAudioBuffer(url, () => {
+		buffers.add(n, buffer);
 
+		log(`sound added: ${n}`);
+		URL.revokeObjectURL(url);
 		// also add soundfiles to menu for easy selection
 		let m = document.getElementById('sounds');
 		let o = document.createElement('option');
@@ -275,4 +279,4 @@ async function record(on, f){
 	}
 }
 
-module.exports = { resume, silence, setBPM, getBPM, randomBPM, getBuffers, addBuffers, setLowPass, setHiPass, setVolume, record, isRecording };
+module.exports = { resume, silence, setBPM, getBPM, randomBPM, getBuffers, addBuffers, setLowPass, setHiPass, setVolume, record, isRecording, addBufferFromURL };

--- a/src/engine.js
+++ b/src/engine.js
@@ -25,7 +25,7 @@ console.log(`PPQ: ${Tone.Transport.PPQ}`);
 // 	console.log('downloading sounds...');
 // }, 2500);
 
-let samples = require('./data/samples.json');
+const defaultSamples = require('./data/samples.json');
 let buffers = new Tone.ToneAudioBuffers();
 // let buffers = new Tone.ToneAudioBuffers({
 // 	urls: samples,
@@ -110,10 +110,16 @@ function getBuffers(){
 	return buffers;
 }
 
+// load all the default samples from the json
 function addDefaultBuffers(){
-	Object.keys(samples).forEach((s) => {
-		addBufferFromURL(samples[s], s);
+	Object.keys(defaultSamples).forEach((s) => {
+		addBufferFromURL(defaultSamples[s], s);
 	});
+}
+
+// get all the default samples
+function getDefaultSamples(){
+	return defaultSamples;
 }
 
 // add files to the buffer from a single File Link
@@ -159,8 +165,8 @@ function addBufferFromURL(url, n){
 
 	// can't have 2 samples with the sample name loaded
 	if (buffers.has(n)){
-		log(`sound '${n}' was already added to the library`);
-		return;
+		log(`sound '${n}' was already added - but gets overwritten`);
+		// return;
 	}
 	log(`loading sample: ${n}`);
 
@@ -290,4 +296,4 @@ async function record(on, f){
 	}
 }
 
-module.exports = { resume, silence, setBPM, getBPM, randomBPM, getBuffers, addBuffers, setLowPass, setHiPass, setVolume, record, isRecording, addBufferFromURL, addDefaultBuffers };
+module.exports = { resume, silence, setBPM, getBPM, randomBPM, getBuffers, addBuffers, setLowPass, setHiPass, setVolume, record, isRecording, addBufferFromURL, addDefaultBuffers, getDefaultSamples };

--- a/src/main.js
+++ b/src/main.js
@@ -46,12 +46,12 @@ window.onload = () => {
 			console.olog = () => {};
 		}
 	}
-	console.log = (...message) => {
-		console.olog(...message);
-		document.getElementById('log').innerHTML += `${message}<br>`;
-		// document.getElementById('console-log').innerHTML += `${message}<br>`
-	};
-	console.error = console.debug = console.info = console.log;
+	// console.log = (...message) => {
+	// 	console.olog(...message);
+	// 	document.getElementById('log').innerHTML += `${message}<br>`;
+	// 	// document.getElementById('console-log').innerHTML += `${message}<br>`
+	// };
+	// console.error = console.debug = console.info = console.log;
 
 	// global log function for in-window console
 	window.log = (print) => {

--- a/src/main.js
+++ b/src/main.js
@@ -27,32 +27,6 @@ window.onbeforeunload = function() {
 };
 
 window.onload = () => {
-	// load requires
-	const Tone = require('tone');
-	Tone.UserMedia.enumerateDevices().then((devices) => {
-		// print the device labels
-		window.devices = devices.map(device => device.label);
-		console.log("=> Input devices");
-		window.devices.forEach((i) => {
-			console.log(`- input: ${i}`);
-		});
-	});
-	
-	// console.log catch function
-	if (typeof console != "undefined"){ 
-		if (typeof console.log != 'undefined'){
-			console.olog = console.log;
-		} else {
-			console.olog = () => {};
-		}
-	}
-	// console.log = (...message) => {
-	// 	console.olog(...message);
-	// 	document.getElementById('log').innerHTML += `${message}<br>`;
-	// 	// document.getElementById('console-log').innerHTML += `${message}<br>`
-	// };
-	// console.error = console.debug = console.info = console.log;
-
 	// global log function for in-window console
 	window.log = (print) => {
 		// console.log('printing', typeof print);
@@ -66,6 +40,32 @@ window.onload = () => {
 
 		console.log(print);
 	}
+
+	// load requires
+	const Tone = require('tone');
+	Tone.UserMedia.enumerateDevices().then((devices) => {
+		// print the device labels
+		window.devices = devices.map(device => device.label);
+		log("Input devices:");
+		window.devices.forEach((i) => {
+			log(`  - input: ${i}`);
+		});
+	});
+	
+	// console.log catch function
+	// if (typeof console != "undefined"){ 
+	// 	if (typeof console.log != 'undefined'){
+	// 		console.olog = console.log;
+	// 	} else {
+	// 		console.olog = () => {};
+	// 	}
+	// }
+	// console.log = (...message) => {
+	// 	console.olog(...message);
+	// 	document.getElementById('log').innerHTML += `${message}<br>`;
+	// 	// document.getElementById('console-log').innerHTML += `${message}<br>`
+	// };
+	// console.error = console.debug = console.info = console.log;
 
 	const Engine = require('./engine.js');
 	const Editor = require('./editor.js');	
@@ -117,11 +117,12 @@ window.onload = () => {
 	window.midiEnable = true;
 
 	window.printMidiDevices = function(){
+		log(`MIDI input/output devices:`)
 		WebMidi.inputs.forEach((i) => {
-			log(`- midi input: ${i.name}`);
+			log(`  - midi input: ${i.name}`);
 		});
 		WebMidi.outputs.forEach((i) => {
-			log(`- midi output: ${i.name}`);
+			log(`  - midi output: ${i.name}`);
 		});
 	}
 

--- a/src/main.js
+++ b/src/main.js
@@ -199,7 +199,7 @@ window.onload = () => {
 	cm.tutorialMenu();
 	cm.soundsMenu();
 	// cm.modeSwitch();
-	cm.soundsListenMenu();
+	// cm.soundsListenMenu();
 	// cm.settingsMenu();
 	
 	// Load recent code from localStorage if any

--- a/src/worker.js
+++ b/src/worker.js
@@ -139,13 +139,15 @@ function code({ file, engine, canvas, p5canvas }){
 			// log(`set bpm to ${args[0]} Hz`);
 		},
 		'samples' : (args) => {
-			// load samples in the audiobuffer
-			// this can be a single url to a soundfile
-			// or a url to a folder that will be searched through
-			// console.log('Loading samples', args);
-			engine.addBuffers(args);
-			// args.forEach((a) => {
-			// });
+			// if the argument is "default", load all the default samples
+			if (args[0] === 'default'){
+				engine.addDefaultBuffers();
+			} else {
+				// load samples in the audiobuffer
+				// this can be a single url to a soundfile
+				// or a url to a folder that will be searched through
+				engine.addBuffers(args);
+			}
 		},
 		'midiDelay' : (args) => {
 			// set some additional latency for all the midi


### PR DESCRIPTION
This update to the mercury-playground makes use of so called [Lazy Loading](https://www.geeksforgeeks.org/javascript/what-is-lazy-loading/). This means that the samples are only loaded once they are need by the sequencer based on the code you type.

The main reason to change to this technique is to have:
- Faster Initial Page Load: By only loading the necessary content first, you can start interacting with the playground sooner.
- Reduced Bandwidth Usage: Unnecessary resources are not loaded unless required, saving data.

One possible downside of this technique:
- When evaluating some code you will not hear the sample immediately if it was not loaded before, this will result in hearing some "gaps" in the sound (silences) while the sample is still loading.

You can evaluate: `set samples default` once to load all the sounds at once. This can be useful if you plan to start a performance and you want to have all the files available you to you.